### PR TITLE
Add theme selector

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,7 +14,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= theme %>">
+	<link id="theme" rel="stylesheet" href="<%= defaulttheme %>">
 
 	<link rel="shortcut icon" href="/img/favicon.png">
 	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">
@@ -219,6 +219,20 @@
 								<label class="opt">
 									<input type="checkbox" name="colors">
 									Enable colored nicknames
+								</label>
+							</div>
+							<div class="col-sm-12">
+								<label class="opt">
+									<select id="themeselect" name="themeselect">
+									<% themes.forEach(function(theme) { %>
+									  <option value="<%= theme.path %>" 
+									  <% if (theme.default) { %>
+									  selected
+									  <% } %>
+									  ><%= theme.name %></option> 
+									  <% }) %>
+									</select>
+									&nbsp;Theme
 								</label>
 							</div>
 							<% if (typeof prefetch === "undefined" || prefetch !== false) { %>

--- a/client/index.html
+++ b/client/index.html
@@ -215,13 +215,13 @@
 							<div class="col-sm-12">
 								<h2>Visual Aids</h2>
 							</div>
-							<div class="col-sm-12">
+							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="colors">
 									Enable colored nicknames
 								</label>
 							</div>
-							<div class="col-sm-12">
+							<div class="col-sm-6">
 								<label class="opt">
 									<select id="themeselect" name="themeselect">
 									<% themes.forEach(function(theme) { %>

--- a/client/index.html
+++ b/client/index.html
@@ -14,7 +14,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= defaulttheme %>">
+	<link id="theme" rel="stylesheet">
 
 	<link rel="shortcut icon" href="/img/favicon.png">
 	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">

--- a/client/index.html
+++ b/client/index.html
@@ -225,12 +225,12 @@
 								<label class="opt">
 									<select id="themeselect" name="themeselect">
 									<% themes.forEach(function(theme) { %>
-									  <option value="<%= theme.path %>" 
-									  <% if (theme.default) { %>
-									  selected
-									  <% } %>
-									  ><%= theme.name %></option> 
-									  <% }) %>
+										<option value="<%= theme.path %>" 
+										<% if (theme.default) { %>
+										selected
+										<% } %>
+										><%= theme.name %></option> 
+									<% }) %>
 									</select>
 									&nbsp;Theme
 								</label>

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -362,6 +362,10 @@ $(function() {
 		}
 	}
 
+	$('#themeselect').on('change', function() {
+		$('#theme').attr('href',$(this).val());
+	});
+
 	settings.on("change", "input", function() {
 		var self = $(this);
 		var name = self.attr("name");

--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -362,8 +362,15 @@ $(function() {
 		}
 	}
 
+	if($.cookie("theme") != null) {
+		$('#themeselect').val($.cookie("theme")).change();
+	}
+
+	$('#theme').attr('href',$('#themeselect').val());
+
 	$('#themeselect').on('change', function() {
 		$('#theme').attr('href',$(this).val());
+		$.cookie("theme", $(this).val()), options, {expires: expire(365)};
 	});
 
 	settings.on("change", "input", function() {

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -34,10 +34,40 @@ module.exports = {
 	//
 	bind: undefined,
 
+	//
+	// Themes
+	//
+	// @type     array
+	//
 	themes: [
+		//
+		// A theme
+		//
+		// @type     object
+		//
 		{
+			//
+			// Name
+			//
+			// @type     string
+			// @default  "Default"
+			//
       		"name": "Default",
+      		
+      		//
+			// Path to the theme CSS
+			//
+			// @type     string
+			// @default  ""
+			//
       		"path": "",
+
+      		//
+			// Set the theme as default
+			//
+			// @type     boolean
+			// @default  false
+			//
       		"default": true
       	},
       	{

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -40,7 +40,30 @@ module.exports = {
 	// @type     string
 	// @default  "themes/example.css"
 	//
-	theme: "themes/example.css",
+	defaulttheme: "themes/example.css",
+
+	themes: [
+		{
+      		"name": "Default",
+      		"path": "themes/example.css",
+      		"default": true
+      	},
+      	{
+      		"name": "Morning",
+      		"path": "themes/morning.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Zenburn",
+      		"path": "themes/zenburn.css",
+      		"default": false
+      	},
+      	{
+      		"name": "Crypto",
+      		"path": "themes/crypto.css",
+      		"default": false
+      	}
+	],
 
 	//
 	// Autoload users

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -34,18 +34,10 @@ module.exports = {
 	//
 	bind: undefined,
 
-	//
-	// Set the default theme.
-	//
-	// @type     string
-	// @default  "themes/example.css"
-	//
-	defaulttheme: "themes/example.css",
-
 	themes: [
 		{
       		"name": "Default",
-      		"path": "themes/example.css",
+      		"path": "",
       		"default": true
       	},
       	{


### PR DESCRIPTION
Adds a theme selector to the settings that allows users to choose a different theme. Themes are managed in config.js and consist of only a CSS file. The default config.js now comes with the default theme and the other 3 that are come in the themes folder preconfigured. 

Users should either add the new theme stuff and remove the old variable, or regenerate a new config.js.

Closes #1.

![screen shot 2015-08-05 at 04 25 08](https://cloud.githubusercontent.com/assets/1300395/9088404/7d23fb28-3b55-11e5-9d3e-b03f4638bf33.png)