### PR TITLE
Rename some things in the client's settings

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -213,12 +213,12 @@
 								</label>
 							</div>
 							<div class="col-sm-12">
-								<h2>Visual Aids</h2>
+								<h2>Visuals</h2>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="colors">
-									Enable colored nicknames
+									Enable colored nicks
 								</label>
 							</div>
 							<div class="col-sm-6">


### PR DESCRIPTION
"Visual Aids" → "Visuals"
"Enable colored nicknames" → "Enable colored nicks"

Before:
![screen shot 2015-08-07 at 01 16 40](https://cloud.githubusercontent.com/assets/1300395/9129834/293637bc-3ca2-11e5-9912-400bd03e5efc.png)
After:
![screen shot 2015-08-07 at 01 15 49](https://cloud.githubusercontent.com/assets/1300395/9129835/2d2eab9c-3ca2-11e5-855a-2e41ad174f8d.png)

Reasons: "Visuals" is more fitting now that themes are also there. "Nick" is the word that is used elsewhere in the settings rather than "nickname."