### PR TITLE
Fix /mode and add /umode

### DIFF
--- a/client/js/shout.js
+++ b/client/js/shout.js
@@ -24,6 +24,7 @@ $(function() {
 		"/server",
 		"/slap",
 		"/topic",
+		"/umode",
 		"/voice",
 		"/whois"
 	];

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -1,5 +1,5 @@
 module.exports = function(network, chan, cmd, args) {
-	if (cmd != "mode" && cmd != "op" && cmd != "voice" && cmd != "deop" && cmd != "devoice") {
+	if (cmd != "mode" && cmd != "op" && cmd != "voice" && cmd != "deop" && cmd != "devoice" && cmd != "umode") {
 		return;
 	} else if (args.length === 0) {
 		return;
@@ -9,7 +9,7 @@ module.exports = function(network, chan, cmd, args) {
 	var flags;
 	var params;
 
-	if (cmd != "mode") {
+	if (cmd != "mode" && cmd != "umode") {
 		params = args[0];
 		flags = {
 		     "op": "+o",
@@ -18,9 +18,13 @@ module.exports = function(network, chan, cmd, args) {
 		"devoice": "-v"
 		}[cmd];
 		target = chan.name;
+	} else if (cmd == "umode") {
+		target = network.irc.me;
+		flags = args[0];
+		params = args.slice(1).join(" ");
 	} else if (args.length === 1) {
 		return;
-	} else if((args[0].slice(0, 1) == '+') || (args[0].slice(0, 1) == '-')) {
+	} else if ((args[0].slice(0, 1) == '+') || (args[0].slice(0, 1) == '-')) {
 		target = chan.name;
 		flags = args[0];
 		params = args.slice(1).join(" ");

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -5,26 +5,30 @@ module.exports = function(network, chan, cmd, args) {
 		return;
 	}
 	
-	var mode;
-	var user;
+	var target;
+	var flags;
+	var params;
+
 	if (cmd != "mode") {
-		user = args[0];
-		mode = {
+		params = args[0];
+		flags = {
 		     "op": "+o",
 		  "voice": "+v",
 		   "deop": "-o",
 		"devoice": "-v"
 		}[cmd];
+		target = chan.name;
 	} else if (args.length === 1) {
 		return;
+	} else if((args[0].slice(0, 1) == '+') || (args[0].slice(0, str.length) == '-')) {
+		target = chan.name;
+		flags = args[0];
+		params = args.slice(1).join(" ");
 	} else {
-		mode = args[0];
-		user = args[1];
+		target = args[0];
+		flags = args[1];
+		params = args.slice(2).join(" ");
 	}
 	var irc = network.irc;
-	irc.mode(
-		chan.name,
-		mode,
-		user
-	);
+	irc.mode(target, flags, params);
 };

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -20,7 +20,7 @@ module.exports = function(network, chan, cmd, args) {
 		target = chan.name;
 	} else if (args.length === 1) {
 		return;
-	} else if((args[0].slice(0, 1) == '+') || (args[0].slice(0, str.length) == '-')) {
+	} else if((args[0].slice(0, 1) == '+') || (args[0].slice(0, 1) == '-')) {
 		target = chan.name;
 		flags = args[0];
 		params = args.slice(1).join(" ");


### PR DESCRIPTION
Closes #48 

Fixes /mode to be a lot more versatile and adds /umode for quick, easy, user modes.

New Commands:
`/mode <target> <flags> [params]` - target can be a user or channel, the same as the offical `MODE` IRC command in [RFC 1459: Section 4.2.3](https://tools.ietf.org/html/rfc1459#section-4.2.3)
`/mode <flags> [<params>]` - target is current channel
`/umode <flags> [<params>]` - target is your nick

Please test this and give feedback if anything doesn't work.